### PR TITLE
Fix "use strict" error in memcached.ascii.commands.js

### DIFF
--- a/lib/memcached.ascii.commands.js
+++ b/lib/memcached.ascii.commands.js
@@ -365,7 +365,7 @@ function MemcachedStatsCommand () {
 
 		var result = "";
 		// use MemcachedStatistics members as is
-		for (x in memcached.stats) {
+		for (var x in memcached.stats) {
 			if (x.substring(0,1) == '_') continue; //private member
 			var val = memcached.stats[x];
 			val = (typeof val === "function" ? memcached.stats[x]() : val) //execute if it's a function


### PR DESCRIPTION
"use strict" error with an undefined "x" variable
